### PR TITLE
rem query & eth-api from docker start

### DIFF
--- a/src/bin/install_testnet.sh
+++ b/src/bin/install_testnet.sh
@@ -169,8 +169,6 @@ docker run -d \
     --checkpoint-file=/root/checkpoint.toml \
     --tendermint-host 0.0.0.0 \
     --tendermint-node-key-config-path="/root/.tendermint/config/priv_validator_key.json" \
-    --enable-query-service \
-    --enable-eth-api-service
 
 sleep 10
 

--- a/src/bin/migrate_mainnet.sh
+++ b/src/bin/migrate_mainnet.sh
@@ -97,8 +97,6 @@ docker run -d \
     --ledger-dir /tmp/findora \
     --tendermint-host 0.0.0.0 \
     --tendermint-node-key-config-path="/root/.tendermint/config/priv_validator_key.json" \
-    --enable-query-service \
-    --enable-eth-api-service
 
 sleep 15
 

--- a/src/bin/migrate_testnet.sh
+++ b/src/bin/migrate_testnet.sh
@@ -99,8 +99,6 @@ docker run -d \
     --checkpoint-file=/root/checkpoint.toml \
     --tendermint-host 0.0.0.0 \
     --tendermint-node-key-config-path="/root/.tendermint/config/priv_validator_key.json" \
-    --enable-query-service \
-    --enable-eth-api-service
 
 sleep 30
 

--- a/src/bin/safety_clean_mainnet.sh
+++ b/src/bin/safety_clean_mainnet.sh
@@ -65,8 +65,6 @@ docker run -d \
     --ledger-dir /tmp/findora \
     --tendermint-host 0.0.0.0 \
     --tendermint-node-key-config-path="/root/.tendermint/config/priv_validator_key.json" \
-    --enable-query-service \
-    --enable-eth-api-service
 
 sleep 25
 

--- a/src/bin/safety_clean_mainnet_eu.sh
+++ b/src/bin/safety_clean_mainnet_eu.sh
@@ -65,8 +65,6 @@ docker run -d \
     --ledger-dir /tmp/findora \
     --tendermint-host 0.0.0.0 \
     --tendermint-node-key-config-path="/root/.tendermint/config/priv_validator_key.json" \
-    --enable-query-service \
-    --enable-eth-api-service
 
 sleep 25
 

--- a/src/bin/safety_clean_testnet.sh
+++ b/src/bin/safety_clean_testnet.sh
@@ -74,8 +74,6 @@ docker run -d \
     --checkpoint-file=/root/checkpoint.toml \
     --tendermint-host 0.0.0.0 \
     --tendermint-node-key-config-path="/root/.tendermint/config/priv_validator_key.json" \
-    --enable-query-service \
-    --enable-eth-api-service
 
 sleep 25
 

--- a/src/bin/update_mainnet.sh
+++ b/src/bin/update_mainnet.sh
@@ -40,8 +40,6 @@ docker run -d \
     --ledger-dir /tmp/findora \
     --tendermint-host 0.0.0.0 \
     --tendermint-node-key-config-path="/root/.tendermint/config/priv_validator_key.json" \
-    --enable-query-service \
-    --enable-eth-api-service
 
 sleep 45
 

--- a/src/bin/update_testnet.sh
+++ b/src/bin/update_testnet.sh
@@ -42,8 +42,6 @@ docker run -d \
     --checkpoint-file=/root/checkpoint.toml \
     --tendermint-host 0.0.0.0 \
     --tendermint-node-key-config-path="/root/.tendermint/config/priv_validator_key.json" \
-    --enable-query-service \
-    --enable-eth-api-service
 
 sleep 30
 

--- a/src/config.py
+++ b/src/config.py
@@ -11,7 +11,7 @@ def getUrl() -> None:
 
 
 class findora_env:
-    toolbox_version = '1.1.6'
+    toolbox_version = '1.1.7'
     server_host_name = socket.gethostname()
     user_home_dir = os.path.expanduser("~")
     dotenv_file = f"{user_home_dir}/.findora.env"


### PR DESCRIPTION
Removing this from all scripts in docker container start command:

    --enable-query-service \
    --enable-eth-api-service
